### PR TITLE
xgb에러 부분해결

### DIFF
--- a/third project.ipynb
+++ b/third project.ipynb
@@ -825,7 +825,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\kssg1\\AppData\\Local\\Temp\\ipykernel_33680\\1436924818.py:30: RuntimeWarning: divide by zero encountered in scalar divide\n",
+      "C:\\Users\\kssg1\\AppData\\Local\\Temp\\ipykernel_13404\\1436924818.py:30: RuntimeWarning: divide by zero encountered in scalar divide\n",
       "  num_bin = entire_range / bin_width\n"
      ]
     },
@@ -2222,6 +2222,7 @@
     "            data[col] = data[col].cat.reorder_categories(loan_rating_list, ordered=False)\n",
     "    return None\n",
     "\n",
+    "# object에서 category로 바꿔주는 것이 상황에 따라 다른데 지금 상황에서는 크게 이익되는 부분이 없는 듯하여 주석처리\n",
     "# X_train\n",
     "type_change_category(X_train, category_col) #얘들도 알아서 전역변수로 인식되어 잘 반영되었음\n",
     "# X_test\n",
@@ -3313,7 +3314,7 @@
     "# def get_multiple_categories(x):\n",
     "\n",
     "# y값 매칭해줄 정보 딕셔너리    \n",
-    "y_dict = {'G': 1, 'F': 2, 'E': 3, 'D': 4, 'C': 5, 'B': 6, 'A': 7}\n",
+    "y_dict = {'G': 1, 'F': 2, 'E': 3, 'D': 4, 'C': 5, 'B': 6, 'A': 7} # {'A': 7, 'B': 6, 'C': 5, 'D': 4, 'E': 3, 'F': 2, 'G': 1}\n",
     "    \n",
     "# 확인용 미리 저장\n",
     "#y_train_original = y_train.copy()\n",
@@ -3418,11 +3419,36 @@
     "    train_dummies = pd.get_dummies(train[category_col+additional_category_col])\n",
     "    test_dummies = pd.get_dummies(test[category_col+additional_category_col])\n",
     "    \n",
-    "    # 더미화한 변수를 기존 데이터셋에 합치기\n",
-    "    train = pd.concat([train, train_dummies], axis = 1)\n",
-    "    test = pd.concat([test, test_dummies], axis = 1)\n",
+    "    # 아래 xgb부분에서 feature_name에 특수기호 들어가면 안된다고 에러가 나서 해당하는 부분 이름 바꿔주기\n",
+    "    # feature_name에 특수기호 + <등 들어가 에러가나서 (get_dummies하는 부분에서 추가된 컬럼들)\n",
+    "    # 나중에 해당부분 get_dummies로 안할경우를 대비해 조건문 등으로 이런 컬럼이 있을 때만 이름을 바꿔주게 설정해줘야함\n",
+    "    if ('근로기간_<1 year' in train_dummies.columns) or ('근로기간_10+ years' in train_dummies.columns):\n",
+    "        rename_dict = {\n",
+    "            '근로기간_<1 year': '근로기간_less_1 year',\n",
+    "            '근로기간_10+ years': '근로기간_10_more years'\n",
+    "        }\n",
+    "        train_dummies.rename(columns=rename_dict, inplace=True)\n",
+    "        test_dummies.rename(columns=rename_dict, inplace=True)\n",
+    "        \n",
+    "        \n",
+    "        # 더미화한 변수를 기존 데이터셋에 합치기\n",
+    "        train = pd.concat([train, train_dummies], axis = 1)\n",
+    "        test = pd.concat([test, test_dummies], axis = 1)\n",
     "    \n",
     "    return train, test, train_dummies.columns.to_list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "'''['대출기간_ 36 months','대출기간_ 60 months','근로기간_Unknown','근로기간_less_1 year','근로기간_1 year',\n",
+    "                             '근로기간_2 years','근로기간_3 years','근로기간_4 years','근로기간_5 years','근로기간_6 years','근로기간_7 years',\n",
+    "                             '근로기간_8 years','근로기간_9 years','근로기간_10_more years','주택소유상태_MORTGAGE','주택소유상태_OWN',\n",
+    "                             '주택소유상태_RENT','대출목적_기타','대출목적_부채 통합','대출목적_소규모 사업','대출목적_신용 카드','대출목적_의료',\n",
+    "                             '대출목적_이사','대출목적_자동차','대출목적_재생 에너지','대출목적_주요 구매','대출목적_주택','대출목적_주택 개선',\n",
+    "                             '대출목적_휴가','최근_2년간_연체_여부_no','최근_2년간_연체_여부_yes','연체_여부(총금액)_no','연체_여부(총금액)_yes',\n",
+    "                             '연체_여부(계좌수)_no','연체_여부(계좌수)_yes']'''"
    ]
   },
   {
@@ -3723,10 +3749,26 @@
     "            \n",
     "        elif model_type == 'xgb':\n",
     "            from xgboost import XGBClassifier\n",
-    "            model_xgb = XGBClassifier(random_state= 42)\n",
-    "            model_xgb.fit(X_train, y_train['대출등급_en'])\n",
-    "            y_pred_train = model_xgb.predict(X_train)\n",
-    "            y_pred_test = model_xgb.predict(X_test)\n",
+    "            # xgb의 경우에만 인코딩을 0부터 연속적인 클래스 값 써줘야하는 것 같은 느낌?\n",
+    "            # 기존의 클래스 값을 수정하여 새로운 변수에 할당합니다.\n",
+    "            # y_train_xgb_encoded = y_train['대출등급_en'].cat.codes - 1\n",
+    "            # y_test_xgb_encoded = y_test['대출등급_en'].cat.codes - 1\n",
+    "            y_train_xgb_encoded = y_train['대출등급_en'].copy().astype(int) - 1\n",
+    "            y_test_xgb_encoded = y_test['대출등급_en'].copy().astype(int) - 1\n",
+    "            # 아래 예측값 부분도 나올 때 다른 것과 통일 시켜주는 과정 해줘야하는데 이부분도 함수나 변수 등으로 한번에 해주면 좋을 것 같음\n",
+    "            display(pd.concat([y_train['대출등급_en'], y_train_xgb_encoded], axis = 1))\n",
+    "            model_xgb = XGBClassifier(objective='multi:softprob', random_state= 42, eval_metric='merror')\n",
+    "            # objective='multi:softmax'# mlogloss, merror # , classes=y_dict.values()\n",
+    "            \n",
+    "            model_xgb.fit(X_train, y_train_xgb_encoded)\n",
+    "            # 예측을 수행합니다.\n",
+    "            y_pred_train_xgb = model_xgb.predict(X_train)\n",
+    "            y_pred_test_xgb = model_xgb.predict(X_test)\n",
+    "            \n",
+    "            # XGBoost 모델의 예측값을 +1하여 기존 클래스 값과 일치하도록 합니다.\n",
+    "            y_pred_train = y_pred_train_xgb + 1\n",
+    "            y_pred_test = y_pred_test_xgb + 1\n",
+    "            \n",
     "            \n",
     "        elif model_type == 'lgb':\n",
     "            from lightgbm import LGBMClassifier\n",
@@ -3793,15 +3835,527 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# xgb 에러 해결할려고 확인한 부분들\n",
+    "# y_train.info()\n",
+    "# y_train.isna().sum()\n",
+    "# print(y_train['대출등급_en'].unique())\n",
+    "# print(y_dict)\n",
+    "# print(y_dict.values())\n",
+    "# print(\"X_train의 행 수:\", len(X_train))\n",
+    "# print(\"y_train의 행 수:\", len(y_train['대출등급_en']))\n",
+    "# print(X_train.columns)\n",
+    "# print(col_dummies)\n",
+    "# pd.set_option('display.max_columns', None)\n",
+    "# X_train.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "lor 사용시\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\kssg1\\AppData\\Local\\Programs\\Python\\Python38\\lib\\site-packages\\sklearn\\linear_model\\_logistic.py:460: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>acc</th>\n",
+       "      <th>rec</th>\n",
+       "      <th>precision</th>\n",
+       "      <th>f1_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>train</th>\n",
+       "      <td>0.43086</td>\n",
+       "      <td>0.26509</td>\n",
+       "      <td>0.37824</td>\n",
+       "      <td>0.27029</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>test</th>\n",
+       "      <td>0.42843</td>\n",
+       "      <td>0.26037</td>\n",
+       "      <td>0.31410</td>\n",
+       "      <td>0.26328</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           acc      rec  precision  f1_score\n",
+       "train  0.43086  0.26509    0.37824   0.27029\n",
+       "test   0.42843  0.26037    0.31410   0.26328"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dt 사용시\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>acc</th>\n",
+       "      <th>rec</th>\n",
+       "      <th>precision</th>\n",
+       "      <th>f1_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>train</th>\n",
+       "      <td>1.00000</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1.0000</td>\n",
+       "      <td>1.00000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>test</th>\n",
+       "      <td>0.82381</td>\n",
+       "      <td>0.7613</td>\n",
+       "      <td>0.7479</td>\n",
+       "      <td>0.75394</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           acc     rec  precision  f1_score\n",
+       "train  1.00000  1.0000     1.0000   1.00000\n",
+       "test   0.82381  0.7613     0.7479   0.75394"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rf 사용시\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>acc</th>\n",
+       "      <th>rec</th>\n",
+       "      <th>precision</th>\n",
+       "      <th>f1_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>train</th>\n",
+       "      <td>1.00000</td>\n",
+       "      <td>1.00000</td>\n",
+       "      <td>1.00000</td>\n",
+       "      <td>1.00000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>test</th>\n",
+       "      <td>0.70103</td>\n",
+       "      <td>0.50181</td>\n",
+       "      <td>0.68253</td>\n",
+       "      <td>0.53122</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           acc      rec  precision  f1_score\n",
+       "train  1.00000  1.00000    1.00000   1.00000\n",
+       "test   0.70103  0.50181    0.68253   0.53122"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "knn 사용시\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>acc</th>\n",
+       "      <th>rec</th>\n",
+       "      <th>precision</th>\n",
+       "      <th>f1_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>train</th>\n",
+       "      <td>0.54475</td>\n",
+       "      <td>0.44122</td>\n",
+       "      <td>0.49251</td>\n",
+       "      <td>0.46078</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>test</th>\n",
+       "      <td>0.32500</td>\n",
+       "      <td>0.21900</td>\n",
+       "      <td>0.23194</td>\n",
+       "      <td>0.22332</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           acc      rec  precision  f1_score\n",
+       "train  0.54475  0.44122    0.49251   0.46078\n",
+       "test   0.32500  0.21900    0.23194   0.22332"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gbm 사용시\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>acc</th>\n",
+       "      <th>rec</th>\n",
+       "      <th>precision</th>\n",
+       "      <th>f1_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>train</th>\n",
+       "      <td>0.76067</td>\n",
+       "      <td>0.70962</td>\n",
+       "      <td>0.81332</td>\n",
+       "      <td>0.75103</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>test</th>\n",
+       "      <td>0.74696</td>\n",
+       "      <td>0.63517</td>\n",
+       "      <td>0.73929</td>\n",
+       "      <td>0.67459</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           acc      rec  precision  f1_score\n",
+       "train  0.76067  0.70962    0.81332   0.75103\n",
+       "test   0.74696  0.63517    0.73929   0.67459"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>대출등급_en</th>\n",
+       "      <th>대출등급_en</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>42717</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>82476</th>\n",
+       "      <td>6</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21126</th>\n",
+       "      <td>6</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>51988</th>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7272</th>\n",
+       "      <td>4</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>64717</th>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7634</th>\n",
+       "      <td>4</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27667</th>\n",
+       "      <td>7</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>80590</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33408</th>\n",
+       "      <td>6</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>67405 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       대출등급_en  대출등급_en\n",
+       "42717        2        1\n",
+       "82476        6        5\n",
+       "21126        6        5\n",
+       "51988        3        2\n",
+       "7272         4        3\n",
+       "...        ...      ...\n",
+       "64717        3        2\n",
+       "7634         4        3\n",
+       "27667        7        6\n",
+       "80590        2        1\n",
+       "33408        6        5\n",
+       "\n",
+       "[67405 rows x 2 columns]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "xgb 사용시\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>acc</th>\n",
+       "      <th>rec</th>\n",
+       "      <th>precision</th>\n",
+       "      <th>f1_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>train</th>\n",
+       "      <td>0.90872</td>\n",
+       "      <td>0.92118</td>\n",
+       "      <td>0.93207</td>\n",
+       "      <td>0.92649</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>test</th>\n",
+       "      <td>0.84648</td>\n",
+       "      <td>0.75715</td>\n",
+       "      <td>0.81338</td>\n",
+       "      <td>0.78073</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           acc      rec  precision  f1_score\n",
+       "train  0.90872  0.92118    0.93207   0.92649\n",
+       "test   0.84648  0.75715    0.81338   0.78073"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "[LightGBM] [Warning] Found whitespace in feature_names, replace with underlines\n",
-      "[LightGBM] [Info] Auto-choosing row-wise multi-threading, the overhead of testing was 0.001626 seconds.\n",
+      "[LightGBM] [Info] Auto-choosing row-wise multi-threading, the overhead of testing was 0.001546 seconds.\n",
       "You can set `force_row_wise=true` to remove the overhead.\n",
       "And if memory is not enough, you can set `force_col_wise=true`.\n",
       "[LightGBM] [Info] Total Bins 1491\n",
@@ -3812,113 +4366,7 @@
       "[LightGBM] [Info] Start training from score -1.975557\n",
       "[LightGBM] [Info] Start training from score -1.248751\n",
       "[LightGBM] [Info] Start training from score -1.206473\n",
-      "[LightGBM] [Info] Start training from score -1.747717\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "train data\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "array([[  290,     4,     0,     0,     0,     0,     0],\n",
-       "       [    3,  1264,    55,    14,    28,     3,     1],\n",
-       "       [    8,    60,  4159,   672,   193,    49,     7],\n",
-       "       [    7,     6,   437,  7722,   953,   197,    26],\n",
-       "       [    5,     1,    19,   540, 17397,  1250,   124],\n",
-       "       [    0,     0,     4,    29,  1268, 17924,   946],\n",
-       "       [    0,     0,     0,     0,    80,  1165, 10495]], dtype=int64)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "array([[[67088,    23],\n",
-       "        [    4,   290]],\n",
-       "\n",
-       "       [[65966,    71],\n",
-       "        [  104,  1264]],\n",
-       "\n",
-       "       [[61742,   515],\n",
-       "        [  989,  4159]],\n",
-       "\n",
-       "       [[56802,  1255],\n",
-       "        [ 1626,  7722]],\n",
-       "\n",
-       "       [[45547,  2522],\n",
-       "        [ 1939, 17397]],\n",
-       "\n",
-       "       [[44570,  2664],\n",
-       "        [ 2247, 17924]],\n",
-       "\n",
-       "       [[54561,  1104],\n",
-       "        [ 1245, 10495]]], dtype=int64)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "train data\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "array([[  65,   47,    6,    2,    6,    0,    0],\n",
-       "       [  33,  380,  120,   19,   30,    4,    0],\n",
-       "       [  19,   67, 1520,  446,  124,   27,    3],\n",
-       "       [  17,   17,  254, 3099,  506,  100,   13],\n",
-       "       [   8,    2,   25,  294, 7313,  571,   74],\n",
-       "       [   3,    0,    0,   15,  614, 7487,  527],\n",
-       "       [   2,    0,    0,    1,   42,  621, 4366]], dtype=int64)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "array([[[28681,    82],\n",
-       "        [   61,    65]],\n",
-       "\n",
-       "       [[28170,   133],\n",
-       "        [  206,   380]],\n",
-       "\n",
-       "       [[26278,   405],\n",
-       "        [  686,  1520]],\n",
-       "\n",
-       "       [[24106,   777],\n",
-       "        [  907,  3099]],\n",
-       "\n",
-       "       [[19280,  1322],\n",
-       "        [  974,  7313]],\n",
-       "\n",
-       "       [[18920,  1323],\n",
-       "        [ 1159,  7487]],\n",
-       "\n",
-       "       [[23240,   617],\n",
-       "        [  666,  4366]]], dtype=int64)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "[LightGBM] [Info] Start training from score -1.747717\n",
       "lgb 사용시\n"
      ]
     },
@@ -3981,18 +4429,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: total: 11.2 s\n",
-      "Wall time: 2.18 s\n"
+      "CPU times: total: 3min 8s\n",
+      "Wall time: 2min 1s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "# 현재 XGB만 에러가 발생함 연휴 끝나고 확인하여 해결할 예정\n",
-    "# for model in ['lor', 'dt', 'rf', 'knn', 'gbm', 'xgb', 'lgb']:\n",
-    "#     get_score(X_train, X_test, col_dummies + numeric_col, model_type=model, cm_on =False)\n",
+    "for model in ['lor', 'dt', 'rf', 'knn', 'gbm', 'xgb', 'lgb']:\n",
+    "    get_score(X_train, X_test, col_dummies + numeric_col, model_type=model, cm_on =False)\n",
     "# get_score(X_train, X_test, col_dummies + numeric_col, model_type='rf')\n",
-    "get_score(X_train, X_test, col_dummies + numeric_col, model_type='lgb')"
+    "# get_score(X_train, X_test, col_dummies + numeric_col, model_type='xgb')"
    ]
   },
   {


### PR DESCRIPTION
에러난 이유 : xgb는 0부터 순차적으로 레이블? 클래스? 생각하는데 실제는 1,2,3,4,5,6,7로 설정해둬서 달라서 에러 그래서 우선 xgb만을 위해서 인코딩해주었던 값들을 -1씩 해서 새로운 시리즈로 만들었고 그런뒤 그 값을 y값에 입력해서 fit해주었다 그런 뒤 예측값에 대해선 다른 것들과 동일하게 표시되는 것을 보고 싶어서 다시 +1해주어 통일시켜주었다(인코딩 값 범주를)

그런데 이렇게 해서 해결하고나니 다른 에러가 떴다 feature_name에 특수기호 [,] >같은 것이 포함되어있다고 에러가 났다

이것은 feature_name이 학습할 때 참고한 사항들?의 이름인데 따로 지정해주지 않으면(애초에 따로 지정하는 방법도 없는 것 같았다) 넣어준 X데이터의 컬럼들의 이름이 들어가게 되는데 컬럼명이 문제였다

현재 모델에 들어가는 X_train의 컬럼에는 get_dummies로 인해서 컬럼명에 어마어마하게 많은 각 컬럼의 값들의 종류에 대해서 컬럼으로 추가되어있는데 이중 <1 year이라던가 10+ years가 문제가 되었어서 get_dummies만들고나서 get_dummies의 문제가 되는 해당 컬럼명을 미리 바꿔주었다